### PR TITLE
Fix configuration retrieval bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install -r requirements.txt
 Execute the script with the target domain as an argument:
 
 ```bash
-python dns_inspector.py example.com
+python dns_inspectah.py example.com
 ```
 
 The script will display DNS records, their summary, and the email spoofing susceptibility result.

--- a/dns_inspectah.py
+++ b/dns_inspectah.py
@@ -139,14 +139,21 @@ class ConfigManager:
     def get_setting(self, section, setting, fallback=None):
         """
         Retrieves a specific setting from the configuration.
+
         Args:
             section (str): The section in the configuration file.
             setting (str): The setting key to retrieve.
             fallback: The default value to return if the setting is not found.
+
         Returns:
-            The value of the setting, or the fallback value if not found.
+            The value of the setting, or the fallback value if not found. If the
+            retrieved value is a comma separated string it will be returned as a
+            list of stripped items.
         """
-        return self.config.get(section, setting, fallback=fallback)
+        value = self.config.get(section, setting, fallback=fallback)
+        if isinstance(value, str) and ',' in value:
+            return [v.strip() for v in value.split(',')]
+        return value
 
 def main():
     parser = argparse.ArgumentParser(description='DNS Inspection Tool')
@@ -158,7 +165,9 @@ def main():
     config_manager = ConfigManager(args.config)
 
     # Retrieve configuration settings
-    dns_record_types = config_manager.get_setting('DNS', 'record_types', fallback=['A', 'MX', 'TXT'])
+    dns_record_types = config_manager.get_setting(
+        'DNSRecords', 'types', fallback=['A', 'MX', 'TXT']
+    )
 
     # Initialize Inspector with domain and configuration
     inspector = Inspector(args.domain, {'dns_record_types': dns_record_types})


### PR DESCRIPTION
## Summary
- parse comma-separated values from config
- fix section and key name when retrieving DNS record types
- correct example command in the README

## Testing
- `python dns_inspectah.py example.com --config config.ini` *(fails: ModuleNotFoundError: No module named 'dns')*