### PR TITLE
Improve DNS inspector output and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # DNS and Email Security Analyzer
 
-A comprehensive Python script to analyze DNS records and email security settings for a given domain. This script checks for common DNS record types, SPF and DMARC configurations, and evaluates the domain's susceptibility to email spoofing.
+A comprehensive Python script to analyze DNS records for a given domain. This tool enumerates a wide range of DNS record types and reports the results.
 
 ## Features
 
-- Enumerates common DNS records such as A, AAAA, CNAME, MX, NS, PTR, SOA, SRV, and TXT
-- Analyzes SPF and DMARC settings for email security
-- Evaluates the risk of email spoofing based on SPF and DMARC settings
+- Enumerates DNS records for all known types by default
+- Users can override the record type list in `config.ini`
 - Provides a detailed summary of the DNS records found
 - Supports the latest version of Python 3
+- Configurable query delay to avoid DNS rate limiting
 
 ## Installation
 
@@ -32,12 +32,20 @@ Execute the script with the target domain as an argument:
 python dns_inspectah.py example.com
 ```
 
-The script will display DNS records, their summary, and the email spoofing susceptibility result.
+By default the tool queries all DNS record types discovered from `dnspython`.
+You can limit or extend the list by editing the `types` entry in `config.ini`.
+The optional `query_delay` setting controls how long the tool waits between DNS
+lookups to help avoid rate limiting.
+
+The script will display DNS records grouped by type and a brief summary of the
+findings.
 
 ## Contributing
 
-We welcome contributions to improve this script. Feel free to open an issue or submit a pull request on GitHub.
+We welcome contributions to improve this script. Feel free to open an issue or
+submit a pull request on GitHub.
 
 ## License
 
-This script is released under the MIT License. See the [LICENSE](LICENSE) file for more information.
+This script is released under the MIT License. See the [LICENSE](LICENSE) file
+for more information.

--- a/config.ini
+++ b/config.ini
@@ -2,4 +2,7 @@
 list = www, mail, ftp, admin, webmail, blog, dev, ns1, ns2, shop, api, test, beta, support, portal, member, online, site, download
 
 [DNSRecords]
-types = A, AAAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, DNSKEY, DS, RRSIG, TLSA, CAA
+types = ALL
+
+[General]
+query_delay = 0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,4 @@
 dnspython
 requests
-pyopenssl
 pyfiglet
 
-certifi
-idna
-urllib3
-
-termcolor
-beautifulsoup4


### PR DESCRIPTION
## Summary
- extend configuration with `query_delay`
- include a full DNS record list excluding generic `TYPE` codes
- group DNS record output by type and add optional delay
- document query delay and new output style in README

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*