### PR TITLE
Fix newline at EOF

### DIFF
--- a/dns_inspectah.py
+++ b/dns_inspectah.py
@@ -222,3 +222,4 @@ def print_banner(text):
 if __name__ == '__main__':
     print_banner("DNS INSPECTAH")
     main()
+


### PR DESCRIPTION
## Summary
- add missing newline at the end of `dns_inspectah.py`

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError)*