### PR TITLE
Fix newline at end of .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ htmlcov/
 .coverage.*
 .cache
 .pytest_cache
+


### PR DESCRIPTION
## Summary
- append a newline to `.gitignore`

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement dnspython)*