### PR TITLE
Append blank line at end

### DIFF
--- a/dns_inspectah.py
+++ b/dns_inspectah.py
@@ -213,3 +213,4 @@ if __name__ == '__main__':
     print_banner("DNS INSPECTAH")
     main()
 
+


### PR DESCRIPTION
## Summary
- add an extra newline after the `main()` call to ensure spacing

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*