### PR TITLE
Add HTTP header exposure check

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A comprehensive Python script to analyze DNS records for a given domain. This to
 - Supports the latest version of Python 3
 - Detects wildcard DNS records across configured types
 - Validates SSL/TLS certificates for the target domain
-- Performs a basic vulnerability scan of accessible web services
+- Performs a basic vulnerability scan of accessible web services, checking
+  HTTP status codes and revealing `Server` or `X-Powered-By` headers when found
 - Allows configuration of the delay between DNS queries
 
 ## Installation

--- a/dns_inspectah.py
+++ b/dns_inspectah.py
@@ -132,15 +132,30 @@ class VulnerabilityScanner:
 
     def scan_for_vulnerabilities(self):
         """
-        Scans the domain for common web vulnerabilities.
+        Perform a minimal HTTP inspection to highlight obvious exposures.
+
+        This check reports the HTTP status code and prints the values of
+        the ``Server`` and ``X-Powered-By`` headers when present.  Exposed
+        values in these headers can reveal information about the web
+        server and application stack.
         """
-        # Example: Basic check for a sample vulnerability (to be expanded)
         try:
-            response = requests.get(f'http://{self.domain}', timeout=REQUEST_TIMEOUT)
-            if 'vulnerable keyword' in response.text:
-                print(f"[!] Potential vulnerability found in {self.domain}\n")
+            url = f'http://{self.domain}'
+            response = requests.get(url, timeout=REQUEST_TIMEOUT)
+            print(f"[+] {url} responded with status code {response.status_code}")
+
+            server_header = response.headers.get('Server')
+            if server_header:
+                print(f"    [!] Server header exposed: {server_header}")
+
+            powered_header = response.headers.get('X-Powered-By')
+            if powered_header:
+                print(f"    [!] X-Powered-By header exposed: {powered_header}")
+
+            if not server_header and not powered_header:
+                print("    [ ] No informative headers found\n")
             else:
-                print(f"[+] No obvious vulnerabilities found in {self.domain}\n")
+                print()
         except Exception as e:
             print(f"[-] Error scanning {self.domain} for vulnerabilities: {e}\n")
             


### PR DESCRIPTION
## Summary
- perform simple HTTP status and header checks in vulnerability scanner
- document the new checks in README

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*