### PR TITLE
Add configurable query delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ python dns_inspectah.py example.com
 By default the tool queries all DNS record types discovered from `dnspython`.
 You can limit or extend the list by editing the `types` entry in `config.ini`.
 
+You can also adjust the delay between DNS queries by setting `query_delay` under
+the `[Settings]` section of `config.ini`.
+
 The script will display DNS records and a brief summary of the findings.
 
 ## Contributing

--- a/config.ini
+++ b/config.ini
@@ -3,3 +3,6 @@ list = www, mail, ftp, admin, webmail, blog, dev, ns1, ns2, shop, api, test, bet
 
 [DNSRecords]
 types = ALL
+
+[Settings]
+query_delay = 0.5

--- a/dns_inspectah.py
+++ b/dns_inspectah.py
@@ -103,7 +103,7 @@ class Inspector:
     Coordinates the inspection process for a given domain.
     """
     def __init__(self, domain, config):
-        self.domain = Domain(domain, query_delay=QUERY_DELAY)
+        self.domain = Domain(domain, query_delay=config.get('query_delay', QUERY_DELAY))
         self.config = config  # Configuration settings
 
     def inspect(self):
@@ -232,6 +232,11 @@ class ConfigManager:
             return ALL_RECORD_TYPES
 
         if isinstance(value, str):
+            if setting == 'query_delay':
+                try:
+                    return float(value)
+                except ValueError:
+                    return fallback
             if ',' in value:
                 return [v.strip() for v in value.split(',')]
             if value.upper() == 'ALL':
@@ -252,6 +257,7 @@ def main():
         'DNSRecords', 'types', fallback=ALL_RECORD_TYPES
     )
     subdomains = config_manager.get_setting('Subdomains', 'list', fallback=[])
+    query_delay = config_manager.get_setting('Settings', 'query_delay', fallback=QUERY_DELAY)
 
     # Initialize Inspector with domain and configuration
     inspector = Inspector(
@@ -259,6 +265,7 @@ def main():
         {
             'dns_record_types': dns_record_types,
             'subdomains': subdomains,
+            'query_delay': query_delay,
         },
     )
 


### PR DESCRIPTION
## Summary
- support `query_delay` setting in `[Settings]` section
- pass configured delay to `Domain`
- document query delay option

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*