### PR TITLE
Update Codex guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,9 @@
 # Repository Guidelines for Codex
 
-## Testing
-Run the following command after making changes:
+This project uses Python. The following conventions help ensure consistent contributions across Codex repositories.
 
-```bash
-python3 dns_inspectah.py example.com
-```
-
-The script depends on packages listed in `requirements.txt`. If they are not installed, create a virtual environment and run:
+## Environment Setup
+If dependencies from `requirements.txt` are missing, create a virtual environment and install them:
 
 ```bash
 python3 -m venv venv
@@ -15,5 +11,25 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Scripts should run with Python 3.8 or later.
+
+## Testing
+After any change, verify the main script still executes:
+
+```bash
+python3 dns_inspectah.py example.com
+```
+
+## Coding Standards
+- Follow PEP 8 guidelines. If `black` or `flake8` are available, run them before committing.
+- Provide docstrings for all public functions and classes.
+- Use descriptive variable names and keep functions small.
+- Prefer cross-platform compatible code.
+
 ## Documentation
-Use descriptive commit messages and cite relevant files in PR summaries.
+- Write clear commit messages summarizing your changes.
+- Reference modified files in PR summaries using line citations.
+- Update `README.md` when adding features or configuration options.
+
+## Contributing
+Keep these instructions up to date when repository conventions change.


### PR DESCRIPTION
## Summary
- expand the repo's AGENTS guidelines for Codex

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*