### PR TITLE
Improve certificate validation resilience

### DIFF
--- a/dns_inspectah.py
+++ b/dns_inspectah.py
@@ -173,7 +173,7 @@ class SSLValidator:
         """Validate and display certificate issuer and expiry."""
         try:
             context = ssl.create_default_context()
-            with socket.create_connection((self.domain, 443)) as sock:
+            with socket.create_connection((self.domain, 443), timeout=REQUEST_TIMEOUT) as sock:
                 with context.wrap_socket(sock, server_hostname=self.domain) as ssock:
                     cert = ssock.getpeercert()
 


### PR DESCRIPTION
## Summary
- add timeout when establishing SSL connection in SSLValidator

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*