### PR TITLE
Add DMARC, SPF and DKIM checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A comprehensive Python script to analyze DNS records for a given domain. This to
 - Performs a basic vulnerability scan of accessible web services
 - Optionally enumerates common subdomains defined in `config.ini`
 - Supports loading an extended subdomain wordlist via `wordlist_file`
+- Checks DMARC, SPF and DKIM records for common issues
 
 ## Installation
 
@@ -46,9 +47,15 @@ You can limit or extend the list by editing the `types` entry in `config.ini`.
 You can also adjust the delay between DNS queries by setting `query_delay` under
 the `[Settings]` section of `config.ini`.
 
+DKIM selectors to probe can be specified in the `[DKIM]` section using the
+`selectors` option. Provide multiple selectors as a comma-separated list.
+
 To perform a more thorough subdomain search, specify a wordlist file with the
 `wordlist_file` option under `[Subdomains]`. Each line in the file should
 contain a subdomain prefix.
+
+DMARC, SPF and DKIM checks are performed automatically and any issues are
+highlighted in the output.
 
 The script will display DNS records and a brief summary of the findings.
 The summary includes totals for each record type and how many subdomains were discovered.

--- a/config.ini
+++ b/config.ini
@@ -7,3 +7,6 @@ types = ALL
 
 [Settings]
 query_delay = 0.5
+
+[DKIM]
+selectors = default


### PR DESCRIPTION
## Summary
- support TXT lookups for any name via `get_txt_record`
- add DMARC, SPF and DKIM validation helpers
- call the new email security checks from the inspector
- allow DKIM selectors in configuration
- document new options and capabilities

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*