### PR TITLE
Improve selectors handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ You can also adjust the delay between DNS queries by setting `query_delay` under
 the `[Settings]` section of `config.ini`.
 
 DKIM selectors to probe can be specified in the `[DKIM]` section using the
-`selectors` option. Provide multiple selectors as a comma-separated list.
+`selectors` option. A single selector may be given or multiple selectors can be
+provided as a comma-separated list.
 
 To perform a more thorough subdomain search, specify a wordlist file with the
 `wordlist_file` option under `[Subdomains]`. Each line in the file should

--- a/dns_inspectah.py
+++ b/dns_inspectah.py
@@ -400,7 +400,9 @@ class ConfigManager:
         Returns:
             The value of the setting, or the fallback value if not found. If the
             retrieved value is a comma separated string it will be returned as a
-            list of stripped items.
+            list of stripped items. When requesting the ``selectors`` option or
+            when the provided fallback is a list, a single value will also be
+            wrapped in a list.
         """
         value = self.config.get(section, setting, fallback=fallback)
 
@@ -417,6 +419,11 @@ class ConfigManager:
                 return [v.strip() for v in value.split(",")]
             if value.upper() == "ALL":
                 return ALL_RECORD_TYPES
+            if setting == "selectors" or isinstance(fallback, list):
+                return [value.strip()]
+
+        if isinstance(value, list):
+            return value
         return value
 
 


### PR DESCRIPTION
## Summary
- ensure `ConfigManager.get_setting` returns a list when `selectors` is a single value or when the fallback is a list
- document that a single DKIM selector value is allowed

## Testing
- `python3 dns_inspectah.py example.com` *(fails: ModuleNotFoundError: No module named 'dns')*